### PR TITLE
Remove link to securitydashboard.eu

### DIFF
--- a/_site/mediator/feature/2015/03/17/concept.html
+++ b/_site/mediator/feature/2015/03/17/concept.html
@@ -111,7 +111,7 @@ be advised, that one CPU is fully sufficient to run T-Pot.</p>
 
 <p><a name="background"></a>
 # Background
-In the last couple of years, we at Deutsche Telekom’s honeypot project have setup several honeypots in our home networks, Telekom’s access networks and at partner locations all around the globe. The data gathered by those honeypots is a core component for our Early Warning System and feeds the data for the <a href="http://sicherheitstacho.eu">Sicherheitstacho</a> / <a href="http://securitydashboard.eu">Securitydashboard</a>.</p>
+In the last couple of years, we at Deutsche Telekom’s honeypot project have setup several honeypots in our home networks, Telekom’s access networks and at partner locations all around the globe. The data gathered by those honeypots is a core component for our Early Warning System and feeds the data for the <a href="http://sicherheitstacho.eu">Sicherheitstacho / Securitydashboard</a>.</p>
 
 <p>Our experience in setting up honeypot systems at several locations showed that many people were interested in running some kind of honeypot sensor, but were a bit overwhelmed by the setup procedure and maintenance. In the past, we have gathered some experience with configuration management and finally decided to create a honeypot system that is easy to deploy, low maintenance and combines some of the best honeypot technologies in one system.</p>
 


### PR DESCRIPTION
According to whois and what you see on http://securitydashboard.eu/, I think this domain not owned by the Telekom anymore, so I think it's better to remove the link and set the same link (https://sicherheitstacho.eu/) behind both words.