### PR TITLE
Remove outdated link (securitydashboard.eu)

### DIFF
--- a/_posts/2015-03-17-concept.markdown
+++ b/_posts/2015-03-17-concept.markdown
@@ -51,7 +51,7 @@ be advised, that one CPU is fully sufficient to run T-Pot.
 
 <a name="background"></a>
 # Background
-In the last couple of years, we at Deutsche Telekom's honeypot project have setup several honeypots in our home networks, Telekom's access networks and at partner locations all around the globe. The data gathered by those honeypots is a core component for our Early Warning System and feeds the data for the [Sicherheitstacho](http://sicherheitstacho.eu) / [Securitydashboard](http://securitydashboard.eu). 
+In the last couple of years, we at Deutsche Telekom's honeypot project have setup several honeypots in our home networks, Telekom's access networks and at partner locations all around the globe. The data gathered by those honeypots is a core component for our Early Warning System and feeds the data for the [Sicherheitstacho / "Securitydashboard"](http://sicherheitstacho.eu). 
 
 Our experience in setting up honeypot systems at several locations showed that many people were interested in running some kind of honeypot sensor, but were a bit overwhelmed by the setup procedure and maintenance. In the past, we have gathered some experience with configuration management and finally decided to create a honeypot system that is easy to deploy, low maintenance and combines some of the best honeypot technologies in one system.
 


### PR DESCRIPTION
This commit will remove the originally planned English domain, which never came live. 
Reported by @evilon, @hillar and @AlpixTM, thanks again!